### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/admin/MaterialsEditor.tsx
+++ b/src/components/admin/MaterialsEditor.tsx
@@ -71,7 +71,11 @@ export function MaterialsEditor() {
 
   const getYouTubeEmbedUrl = (url?: string | null) => {
     const id = getYouTubeId(url);
-    return id ? `https://www.youtube.com/embed/${id}` : null;
+    // YouTube IDs are exactly 11 characters, only A-Za-z0-9_- allowed
+    if (id && /^[-_A-Za-z0-9]{11}$/.test(id)) {
+      return `https://www.youtube.com/embed/${id}`;
+    }
+    return null;
   };
 
   const loadMaterials = async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/frankmathewsajan/school-verse-portal/security/code-scanning/3](https://github.com/frankmathewsajan/school-verse-portal/security/code-scanning/3)

The key fix is to add strong validation to the code that extracts the YouTube ID and produces the embed URL. Specifically, ensure that:

- The ID is always exactly 11 characters and contains only letters, digits, `-`, and `_`.
- The `getYouTubeId` function should already return only valid IDs — we reinforce this by re-validating the final embed URL creator (`getYouTubeEmbedUrl`) to not accidentally interpolate an unused or malformed ID.
- Add an explicit check in `getYouTubeEmbedUrl` to prevent any output unless the ID is *guaranteed* to match the allowed pattern.
- No HTML interpretation or injection should ever occur — this also means we do not use `dangerouslySetInnerHTML` (which we don't currently).

This requires changing the implementation of `getYouTubeEmbedUrl` (line 72-75) to add a final pattern match before returning the embed URL. All other usages can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
