### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ui/text-with-links.tsx
+++ b/src/components/ui/text-with-links.tsx
@@ -3,6 +3,16 @@ import React from 'react';
 /**
  * Utility function to detect and parse URLs in text
  */
+// Helper: returns true if urlStr is a valid http/https URL, false otherwise.
+const isSafeHttpUrl = (urlStr: string): boolean => {
+  try {
+    const url = new URL(urlStr, 'https://example.com');
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 export const parseTextWithLinks = (text: string): React.ReactNode[] => {
   // Regex to match URLs (http, https, www, or naked domains)
   const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+|[^\s]+\.[a-z]{2,}(?:\/[^\s]*)?)/gi;
@@ -18,18 +28,23 @@ export const parseTextWithLinks = (text: string): React.ReactNode[] => {
       if (!part.startsWith('http://') && !part.startsWith('https://')) {
         href = 'https://' + part;
       }
-      
-      return (
-        <a
-          key={index}
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:text-blue-800 underline break-all"
-        >
-          {part}
-        </a>
-      );
+      // Only render link if url is valid and protocol is safe (http/https)
+      if (isSafeHttpUrl(href)) {
+        return (
+          <a
+            key={index}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 underline break-all"
+          >
+            {part}
+          </a>
+        );
+      } else {
+        // Unsafe protocol or invalid URL, render as plain text
+        return part;
+      }
     }
     
     return part;


### PR DESCRIPTION
Potential fix for [https://github.com/frankmathewsajan/school-verse-portal/security/code-scanning/2](https://github.com/frankmathewsajan/school-verse-portal/security/code-scanning/2)

The best way to fix this issue is to strictly validate and sanitize the user-supplied string before interpolating it into the href attribute of an `<a>` tag. In this context, it is important to:  
1. **Ensure only HTTP/HTTPS links are allowed:**  
   Before rendering a link, check that the URL's scheme is only `http` or `https`. Reject or skip rendering links to any other scheme (such as `javascript:`, `data:`, etc.).  
2. **Normalize the URL:**  
   Use a well-known library such as the browser’s built-in `URL` constructor for parsing and validation, or use a package like `is-url` or `validator` for robust checks (the built-in constructor is adequate and doesn't require new dependencies here).
3. **Implement this sanitation in `parseTextWithLinks` function:**  
   When forming the `href`, use the browser's `URL` constructor to parse the string—if it throws, or the protocol is not `http:` or `https:`, skip rendering the link and output the plain text part.

All changes are within `src/components/ui/text-with-links.tsx`, in the `parseTextWithLinks` function. No new external dependencies are needed. We will add a helper to validate HTTP/HTTPS URLs, use it before rendering the link, and fall back to rendering plain text for other cases.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
