### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ui/text-with-links.tsx
+++ b/src/components/ui/text-with-links.tsx
@@ -29,11 +29,12 @@ export const parseTextWithLinks = (text: string): React.ReactNode[] => {
         href = 'https://' + part;
       }
       // Only render link if url is valid and protocol is safe (http/https)
-      if (isSafeHttpUrl(href)) {
+      const sanitizedHref = sanitizeUrl(href);
+      if (sanitizedHref) {
         return (
           <a
             key={index}
-            href={href}
+            href={sanitizedHref}
             target="_blank"
             rel="noopener noreferrer"
             className="text-blue-600 hover:text-blue-800 underline break-all"


### PR DESCRIPTION
Potential fix for [https://github.com/frankmathewsajan/school-verse-portal/security/code-scanning/4](https://github.com/frankmathewsajan/school-verse-portal/security/code-scanning/4)

To eliminate the risk that user-controllable text could be rendered as a malicious link, we should further filter `href` before assigning it. This can be accomplished by introducing an allowlist of allowed protocols, using the URL API more robustly for parse+validation, and *strictly escaping* or rejecting suspicious values (e.g., those that cannot be parsed as a real `http(s)` URL). To avoid open redirects and spoofed domains, it's good practice to make sure only absolute URLs with safe protocols are used, and reject everything else or render as plain text.

**Specific changes:**  
- In `parseTextWithLinks` (in `src/components/ui/text-with-links.tsx`), right before rendering the anchor link, add more robust sanitization for `href`, ideally by re-parsing with the `URL` constructor and ensuring the origin and protocol are legitimate.
- Optionally, create a helper function like `sanitizeUrl` that can strictly validate or encode URLs.
- Replace direct assignment of `{href}` in the `<a>` tag with the sanitized URL.
- Do not change the external API or the rendered output except for making links more robust and safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
